### PR TITLE
Image resources

### DIFF
--- a/plone/resourceeditor/browser.py
+++ b/plone/resourceeditor/browser.py
@@ -36,7 +36,8 @@ def validateFilename(name):
 
 class FileManagerActions(BrowserView):
 
-    imageExtensions = ['png', 'gif', 'jpg', 'jpeg']
+    imageExtensions = ['png', 'gif', 'jpg', 'jpeg', 'ico']
+    previewTemplate = ViewPageTemplateFile('preview.pt')
 
     @property.Lazy
     def resourceDirectory(self):
@@ -71,7 +72,9 @@ class FileManagerActions(BrowserView):
                 data = data.read()
             result['contents'] = str(data)
         else:
-            info = self.getInfo(path)
+            obj = self.getObject(path)
+            info = self.getInfo(obj)
+            info['preview'] = info['filename']
             result['info'] = self.previewTemplate(info=info)
 
         self.request.response.setHeader('Content-Type', 'application/json')

--- a/plone/resourceeditor/browser.py
+++ b/plone/resourceeditor/browser.py
@@ -74,7 +74,7 @@ class FileManagerActions(BrowserView):
         else:
             obj = self.getObject(path)
             info = self.getInfo(obj)
-            info['preview'] = info['filename']
+            info['preview'] = path
             result['info'] = self.previewTemplate(info=info)
 
         self.request.response.setHeader('Content-Type', 'application/json')


### PR DESCRIPTION
This prevents the FileManagerActions class from breaking when requesting an image resource. The getInfo method was expecting an object, but the path string was being passed instead. Also, the FileManagerActions class didn't have a previewTemplate declared.