### PR TITLE
Added code to register additional non-standard mimetypes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,8 @@ Changelog
 - Fixed issue with ascii encoding [obct537]
 - now properly serves filesystem files to the thememapper 
   [obct537]
+- resourceeditor will now register non-standard mimetypes 
+  in the python mimetype module [obct537]
 
 2.0.0 (2015-03-21)
 ------------------

--- a/plone/resourceeditor/__init__.py
+++ b/plone/resourceeditor/__init__.py
@@ -1,0 +1,19 @@
+import os.path
+import mimetypes
+
+# Borrowed from zope.contenttype.
+# This allows us to register mimetypes that
+# aren't included in python by default
+#
+# To add additional mimetypes, include a line in mime.types
+
+
+def add_files(filenames):
+    if mimetypes.inited:
+        mimetypes.init(filenames)
+    else:
+        mimetypes.knownfiles.extend(filenames)
+
+
+here = os.path.dirname(os.path.abspath(__file__))
+add_files([os.path.join(here, "mime.types")])

--- a/plone/resourceeditor/mime.types
+++ b/plone/resourceeditor/mime.types
@@ -1,0 +1,1 @@
+text/css				css less


### PR DESCRIPTION
@Gagaro @vangheem 

Allows python to give .less files the 'text/css' mimetype, causing them to be rendered correctly in the browser.

This fixes an issue in plone.mockup causing .less files to fail to compile.