### PR TITLE
Relative urls for LESS builder

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- Added ability to convert absolute to relative urls
+  [obct537]
 - Fixed issue with ascii encoding [obct537]
 - now properly serves filesystem files to the thememapper 
   [obct537]

--- a/plone/resourceeditor/browser.py
+++ b/plone/resourceeditor/browser.py
@@ -175,7 +175,7 @@ class FileManagerActions(BrowserView):
         value = unicode(value.strip(), 'utf-8')
         value = value.replace('\r\n', '\n')
         
-        if self.request.form['relativeUrls'] == 'true':
+        if 'relativeUrls' in self.request.form:
             reg = re.compile('url\(([^)]+)\)')
             urls = reg.findall(value)
             

--- a/plone/resourceeditor/browser.py
+++ b/plone/resourceeditor/browser.py
@@ -179,6 +179,7 @@ class FileManagerActions(BrowserView):
             reg = re.compile('url\(([^)]+)\)')
             urls = reg.findall(value)
             
+            #Trim off the @@plone.resourceeditor bit to just give us the theme url
             location = self.request.URL[0:self.request.URL.find('@@plone.resourceeditor')]
             base = urlparse(location)
             for url in urls:

--- a/plone/resourceeditor/browser.py
+++ b/plone/resourceeditor/browser.py
@@ -179,7 +179,7 @@ class FileManagerActions(BrowserView):
             reg = re.compile('url\(([^)]+)\)')
             urls = reg.findall(value)
             
-            location = self.request.URL[0:self.request.URL.find('@@')]
+            location = self.request.URL[0:self.request.URL.find('@@plone.resourceeditor')]
             base = urlparse(location)
             for url in urls:
                 asset = urlparse(url.strip("'").strip('"'))

--- a/plone/resourceeditor/browser.py
+++ b/plone/resourceeditor/browser.py
@@ -1016,7 +1016,6 @@ var BASE_URL = '%s';
     def saveFile(self, path, value):
         processInputs(self.request)
 
-        import pdb; pdb.set_trace()
         path = self.request.form.get('path', path)
         value = self.request.form.get('value', value)
 


### PR DESCRIPTION
Added the option for stripping out absolute urls in the "saveFile" action. This is intended to be used with plone.mockup's thememapper.