### PR TITLE
Added check to prevent saving over folders

### DIFF
--- a/plone/resourceeditor/browser.py
+++ b/plone/resourceeditor/browser.py
@@ -174,7 +174,10 @@ class FileManagerActions(BrowserView):
         path = path.lstrip('/').encode('utf-8')
         value = unicode(value.strip(), 'utf-8')
         value = value.replace('\r\n', '\n')
-        
+
+        if IResourceDirectory.providedBy(self.context[path]):
+           return json.dumps({'error': 'invalid path'})
+
         if 'relativeUrls' in self.request.form:
             reg = re.compile('url\(([^)]+)\)')
             urls = reg.findall(value)


### PR DESCRIPTION
Added check to prevent saving over a folder in the event that an improper path is supplied to the resourceeditor