### PR TITLE
Saving fix

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,11 @@ Changelog
 2.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed problem causing file timestamps to show up incorrectly
+  [obct537]
 
+- Fixed problem error preventing file saving from the filemanager
+  [obct537]
 
 2.0.3 (2015-09-27)
 ------------------

--- a/plone/resourceeditor/browser.py
+++ b/plone/resourceeditor/browser.py
@@ -122,15 +122,13 @@ class FileManagerActions(BrowserView):
         filename = obj.__name__
 
         properties = {
-            'dateCreated': None,
             'dateModified': None,
         }
 
         size = 0
 
         if isinstance(obj, File):
-            properties['dateCreated'] = obj.created().strftime('%c')
-            properties['dateModified'] = obj.modified().strftime('%c')
+            properties['dateModified'] = obj.bobobase_modification_time().strftime('%c')
             size = obj.get_size() / 1024
 
         fileType = self.getExtension(obj)
@@ -138,7 +136,6 @@ class FileManagerActions(BrowserView):
             stats = os.stat(obj.path)
             created = localtime(stats.st_ctime)
             modified = localtime(stats.st_mtime)
-            properties['dateCreated'] = strftime('%c', created)
             properties['dateModified'] = strftime('%c', modified)
             size = stats.st_size / 1024
 
@@ -633,13 +630,11 @@ var BASE_URL = '%s';
         errorCode = 0
 
         properties = {
-            'dateCreated': None,
             'dateModified': None,
         }
 
         if isinstance(obj, File):
-            properties['dateCreated'] = obj.created().strftime('%c')
-            properties['dateModified'] = obj.modified().strftime('%c')
+            properties['dateModified'] = obj.bobobase_modification_time().strftime('%c')
             size = obj.get_size() / 1024
             if size < 1024:
                 size_specifier = u'kb'

--- a/plone/resourceeditor/browser.py
+++ b/plone/resourceeditor/browser.py
@@ -169,8 +169,9 @@ class FileManagerActions(BrowserView):
         value = unicode(value.strip(), 'utf-8')
         value = value.replace('\r\n', '\n')
 
-        if IResourceDirectory.providedBy(self.context[path]):
-            return json.dumps({'error': 'invalid path'})
+        if path in self.context:
+            if IResourceDirectory.providedBy(self.context[path]):
+                return json.dumps({'error': 'invalid path'})
 
         if 'relativeUrls' in self.request.form:
             reg = re.compile('url\(([^)]+)\)')

--- a/plone/resourceeditor/preview.pt
+++ b/plone/resourceeditor/preview.pt
@@ -7,9 +7,6 @@
                               props info/properties;">
     <img src="" tal:attributes="src info/preview" tal:condition="exists:info/preview" />
     <p class="discreet details">
-        <b i18n:translate="file_preview_date_created">Date Created</b>: <span tal:replace="props/dateCreated" />
-            <span tal:condition="not:props/dateCreated">n/a</span>
-        <br/>
         <b i18n:translate="file_preview_date_modified">Date Modified</b>: <span tal:replace="props/dateModified" />
             <span tal:condition="not:props/dateModified">n/a</span>
         <br/>


### PR DESCRIPTION
Fixed issue with file saving via the mockup Filemanager. This was breaking LESS compiling in the thememapper.

Also removed the "Created date" field from the metadata that the resourceeditor attaches to non-text files. It was incorrectly reporting the creation date of the context of the file, and not the file itself. Unfortunately there's currently no way to get the creation date for a file from the resource editor.