### PR TITLE
Remove bobobase_modification_time

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 2.0.4 (unreleased)
 ------------------
 
+- No longer rely on deprecated ``bobobase_modification_time`` from
+  ``Persistence.Persistent``.
+  [thet]
+
 - Minor cleanup (pep8, readability, ReST)
   [jensens]
 
@@ -12,6 +16,7 @@ Changelog
 
 - Fixed problem error preventing file saving from the filemanager
   [obct537]
+
 
 2.0.3 (2015-09-27)
 ------------------

--- a/plone/resourceeditor/browser.py
+++ b/plone/resourceeditor/browser.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from AccessControl import Unauthorized
+from DateTime import DateTime
 from OFS.Image import File, Image
 from plone.resource.file import FilesystemFile
 from plone.resource.interfaces import IResourceDirectory
@@ -125,7 +126,7 @@ class FileManagerActions(BrowserView):
         size = 0
 
         if isinstance(obj, File):
-            properties['dateModified'] = obj.bobobase_modification_time().strftime('%c')  # noqa
+            properties['dateModified'] = DateTime(obj._p_mtime).strftime('%c')
             size = obj.get_size() / 1024
 
         fileType = self.getExtension(obj)
@@ -641,7 +642,7 @@ var BASE_URL = '%s';
         }
 
         if isinstance(obj, File):
-            properties['dateModified'] = obj.bobobase_modification_time().strftime('%c')  # noqa
+            properties['dateModified'] = DateTime(obj._p_mtime).strftime('%c')
             size = obj.get_size() / 1024
             if size < 1024:
                 size_specifier = u'kb'
@@ -651,8 +652,7 @@ var BASE_URL = '%s';
             properties['size'] = '%i%s' % (
                 size,
                 translate(_(u'filemanager_%s' % size_specifier,
-                            default=size_specifier), context=self.request)
-                )
+                            default=size_specifier), context=self.request))
 
         fileType = 'txt'
 


### PR DESCRIPTION
No longer rely on deprecated bobobase_modification_time from Persistence.Persistent.

see changelog for Zope 4.0a1: https://github.com/zopefoundation/Zope/blob/master/CHANGES.rst