### PR TITLE
Do not crash on saving in FilesystemResourceDirectory

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,10 @@ Fixes:
 - Cleanup code according to Plone style guide.
   [gforcada]
 
+- Do not crash on saving in FilesystemResourceDirectory, and return the file
+  content as 'tmp'.
+  [ebrehault]
+
 
 2.0.4 (2015-10-28)
 ------------------


### PR DESCRIPTION
Related to https://github.com/plone/Products.CMFPlone/issues/1468
Depends on https://github.com/plone/mockup/tree/fix-build-css-for-fs-themes